### PR TITLE
list pypng as a packaging dependency in setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,8 @@ setup(
         'Intended Audience :: Developers'
     ],
     install_requires=[
-        'Click >= 6.6'
+        'Click >= 6.6',
+        'pypng >= 0.0.18',
     ],
     entry_points="""
         [console_scripts]


### PR DESCRIPTION
pypng isn't listed in setup `install_requires`, so potentially gets left out when isntalling via pip; problem when using the bakery as a dependency in other projects where testing gets done via virtual envs (i.e. tox, and the like).