### PR TITLE
PNG unbake fail when using python3

### DIFF
--- a/openbadges_bakery/png_bakery.py
+++ b/openbadges_bakery/png_bakery.py
@@ -24,7 +24,7 @@ def unbake(imageFile):
         if chunktype == b'iTXt' and content.startswith(b'openbadges\x00'):
             return re.sub(b'openbadges[\x00]+', b'', content).decode('utf8')
         elif chunktype == b'tEXt' and content.startswith(b'openbadges\x00'):
-            return content.split('\x00')[1].decode('utf8')
+            return content.split(b'\x00')[1].decode('utf8')
 
 
 def bake(imageFile, assertion_string, newfile=None):


### PR DESCRIPTION
Experienced the following  error in the badgr application logs when uploading a badge (using python3) :
```
File "/usr/local/lib/python3.7/site-packages/openbadges_bakery/png_bakery.py", line 27, in unbake
    return content.split('\x00')[1].decode('utf8')
TypeError: a bytes-like object is required, not 'str'
```
Seems that the split argument in `content.split('\x00')` needs to be forced to binary `content.split(b'\x00')` 