### PR TITLE
provide correct file extension for baking an svg

### DIFF
--- a/openbadges_bakery/svg_bakery.py
+++ b/openbadges_bakery/svg_bakery.py
@@ -21,7 +21,7 @@ def bake(imageFile, assertion_string, new_file=None):
     svg_body.insertBefore(assertion_node, svg_body.firstChild)
 
     if new_file is None:
-        new_file = NamedTemporaryFile(suffix='.png')
+        new_file = NamedTemporaryFile(suffix='.svg')
 
     new_file.write(svg_doc.toxml('utf-8'))
     new_file.seek(0)


### PR DESCRIPTION
this bug was causing incorrect file name to be encoded in the svg